### PR TITLE
config: add operating-systems conditional configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * A nearly identical string pattern system as revsets is now supported in the
   template language, and is exposed as `string.match(pattern)`.
 
+* Added a new conditional configuration `--when.operating-systems` to include
+  settings only on certain platforms.
+
 ### Fixed bugs
 
 * `jj git clone` now correctly fetches all tags, unless `--fetch-tags` is

--- a/docs/config.md
+++ b/docs/config.md
@@ -1906,3 +1906,14 @@ wip = ["log", "-r", "work"]
   --when.commands = ["file show"]   # matches `jj file show` but *NOT* `jj file list`
   --when.commands = ["file", "log"] # matches `jj file` *OR* `jj log` (or subcommand of either)
   ```
+
+* `--when.operating-systems`: List of operating systems to match.
+
+  The values are defined by
+  [`std::env::consts::OS](https://doc.rust-lang.org/std/env/consts/constant.OS.html).
+
+  ```toml
+  --when.operating-systems = ["linux"]        # matches only linux
+  --when.operating-systems = ["macos"]   # matches `jj file show` but *NOT* `jj file list`
+  --when.commands = ["file", "log"] # matches `jj file` *OR* `jj log` (or subcommand of either)
+  ```

--- a/lib/src/config_resolver.rs
+++ b/lib/src/config_resolver.rs
@@ -67,6 +67,9 @@ struct ScopeCondition {
     /// - `--when.commands = ["foo bar"]` -> matches "foo bar", "foo bar baz",
     ///   NOT "foo"
     pub commands: Option<Vec<String>>,
+    /// Operating systems to match. The values are defined by
+    /// std::env::consts::OS.
+    pub operating_systems: Option<Vec<String>>,
     // TODO: maybe add "workspaces"?
 }
 
@@ -94,6 +97,7 @@ impl ScopeCondition {
 
     fn matches(&self, context: &ConfigResolutionContext) -> bool {
         matches_path_prefix(self.repositories.as_deref(), context.repo_path)
+            && matches_os(self.operating_systems.as_deref())
             && matches_command(self.commands.as_deref(), context.command)
     }
 }
@@ -114,6 +118,12 @@ fn matches_path_prefix(candidates: Option<&[PathBuf]>, actual: Option<&Path>) ->
         (Some(_), None) => false, // actual path not known (e.g. not in workspace)
         (None, _) => true,        // no constraints
     }
+}
+
+fn matches_os(candidates: Option<&[String]>) -> bool {
+    candidates.is_none_or(|candidates| {
+        candidates.is_empty() || candidates.contains(&std::env::consts::OS.to_owned())
+    })
 }
 
 fn matches_command(candidates: Option<&[String]>, actual: Option<&str>) -> bool {
@@ -444,6 +454,7 @@ mod tests {
         let condition = ScopeCondition {
             repositories: Some(["/foo", "/bar"].map(PathBuf::from).into()),
             commands: None,
+            operating_systems: None,
         };
 
         let context = ConfigResolutionContext {
@@ -483,6 +494,7 @@ mod tests {
         let condition = ScopeCondition {
             repositories: Some(["c:/foo", r"d:\bar/baz"].map(PathBuf::from).into()),
             commands: None,
+            operating_systems: None,
         };
 
         let context = ConfigResolutionContext {
@@ -708,6 +720,52 @@ mod tests {
         let resolved_config = resolve(&source_config, &context).unwrap();
         assert_eq!(resolved_config.layers().len(), 1);
         insta::assert_snapshot!(resolved_config.layers()[0].data, @"a = 'a #0'");
+    }
+
+    #[test]
+    fn test_resolve_os_and_command() {
+        let mut source_config = StackedConfig::empty();
+        source_config.add_layer(new_user_layer(indoc! {"
+            a = 'a none'
+            b = 'b none'
+            [[--scope]]
+            --when.operating-systems = ['linux']
+            a = 'a linux'
+            [[--scope]]
+            --when.operating-systems = ['macos']
+            a = 'a macos'
+            [[--scope]]
+            --when.operating-systems = ['windows']
+            a = 'a windows'
+            [[--scope]]
+            --when.operating-systems = ['linux', 'macos']
+            b = 'b linux-macos'
+        "}));
+
+        let context = ConfigResolutionContext {
+            home_dir: Some(Path::new("/home/dir")),
+            repo_path: None,
+            command: None,
+        };
+        let resolved_config = resolve(&source_config, &context).unwrap();
+        insta::assert_snapshot!(resolved_config.layers()[0].data, @r#"
+        a = 'a none'
+        b = 'b none'
+        "#);
+        if cfg!(target_os = "linux") {
+            assert_eq!(resolved_config.layers().len(), 3);
+            insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a linux'");
+            insta::assert_snapshot!(resolved_config.layers()[2].data, @"b = 'b linux-macos'");
+        } else if cfg!(target_os = "macos") {
+            assert_eq!(resolved_config.layers().len(), 3);
+            insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a macos'");
+            insta::assert_snapshot!(resolved_config.layers()[2].data, @"b = 'b linux-macos'");
+        } else if cfg!(target_os = "windows") {
+            assert_eq!(resolved_config.layers().len(), 2);
+            insta::assert_snapshot!(resolved_config.layers()[1].data, @"a = 'a windows'");
+        } else {
+            assert_eq!(resolved_config.layers().len(), 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds a new `--when.operating-systems` condition for including configuration. This is useful when someone syncs their dotfiles across machines.

The values for `operating-systems` are defined by `std::env::consts:OS`. I considered using `std::env::consts:FAMILY` instead, but that doesn't distinguish between Linux and macOS.

Example:

```toml
ui.pager = ["less", "-FRX"]

[[--scope]]
--when.operating-systems = ["windows"]
ui.pager = ["C:/Program Files/Git/usr/bin/less.exe", "-FRX"]
```

<!--
There's no need to add anything here, but feel free to add a personal message.
Please describe the changes in this PR in the commit message(s) instead, with
each commit representing one logical change. Address code review comments by
rewriting the commits rather than adding commits on top. Use force-push when
pushing the updated commits (`jj git push` does that automatically when you
rewrite commits). Merge the PR at will once it's been approved. See
https://github.com/jj-vcs/jj/blob/main/docs/contributing.md for details.
Note that you need to sign Google's CLA to contribute.
-->

# Checklist

If applicable:

- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated the documentation (`README.md`, `docs/`, `demos/`)
- [ ] I have updated the config schema (`cli/src/config-schema.json`)
- [ ] I have added/updated tests to cover my changes
